### PR TITLE
Link to 8 Subdomain finder tools hosted online

### DIFF
--- a/others/subdomain-tools-review.md
+++ b/others/subdomain-tools-review.md
@@ -55,7 +55,7 @@ Well known tool for the enumeration of subdomains. It's basically an all-in-one 
 * Not fast at all.
 * Sometimes usability is confusing due to the large number of options
 
-### [Sublist3r](https://github.com/aboul3la/Sublist3r)
+### [Sublist3r](https://github.com/aboul3la/Sublist3r). [Try Sublist3r Out Online and Amass and 8 others](https://www.nmmapper.com/sys/tools/subdomainfinder/)
 
 * Author: [aboul3la](https://github.com/aboul3la)
 * Language: Python


### PR DESCRIPTION
Added a link to 8 subdomain finder tools most of whom are menitioned in this document. This tools include, Sublist3r, Amass, Findomain, Lepus, Nmap(dns-brute-script) Anubis and more.