### PR TITLE
fix: typo URL in "technology scanner" section

### DIFF
--- a/enumeration/web/quick-tricks.md
+++ b/enumeration/web/quick-tricks.md
@@ -6,7 +6,7 @@
 
 # Technology scanner
 # https://github.com/urbanadventurer/WhatWeb
-whatweb htttps://url.com
+whatweb https://url.com
 
 # Screenshot web
 # https://github.com/maaaaz/webscreenshot


### PR DESCRIPTION
Change htttps:// to https://